### PR TITLE
cmd_usersearch.lua: Only show nick on people of same or higher level.

### DIFF
--- a/scripts/cmd_usersearch.lua
+++ b/scripts/cmd_usersearch.lua
@@ -6,7 +6,7 @@
 
         v1.2: by HypoManiac
             - Only shows nick for users with same or higher level.
-            
+
         v1.1: by blastbeat
             - password only revealed for lower level users  / thx Sopor
 
@@ -55,6 +55,9 @@ local scriptname = "cmd_usersearch"
 local scriptversion = "1.2"
 
 local cmd = "usersearch"
+
+-- Should details be hidden for users of same or higher level
+local hide_details_for_same_or_higher = false
 
 
 ----------------------------
@@ -178,7 +181,7 @@ local onbmsg = function( user, command, parameters )
         if found and not u.is_bot then
             if count <= max_limit then
                 count = count + 1
-                if u.level >= user_level then
+                if u.level >= user_level and hide_details_for_same_or_higher then
                     table_insert( ret, utf_format( msg_result_nick, u.nick ) )
                 else
                     table_insert( ret, utf_format(

--- a/scripts/cmd_usersearch.lua
+++ b/scripts/cmd_usersearch.lua
@@ -98,6 +98,7 @@ local ucmd_menu = lang.ucmd_menu or { "Hub", "etc", "Usersearch" }
 local ucmd_popup = lang.ucmd_popup or "Search registered nick"
 
 local msg_result = lang.msg_result or "\n\tNick: %s \n\tLevel: %s\n\tPassword: %s\n\tRegged by: %s\n\tRegged since: %s\n\tLast seen: %s"
+local msg_result_nick = lang.msg_result_nick or "\n\tNick: %s"
 local msg_no_matches = lang.msg_no_matches or "No matches found"
 local msg_no_allowed = lang.msg_no_allowed or "<Not allowed to view>"
 local msg_unknown = lang.msg_unknown or "<unknown>"
@@ -174,15 +175,19 @@ local onbmsg = function( user, command, parameters )
         if found and not u.is_bot then
             if count <= max_limit then
                 count = count + 1
-                table_insert( ret, utf_format(
-                    msg_result,
-                    u.nick,
-                    u.level or msg_unknown,
-                    ( ( user_level == 100 ) or ( user_level > ( u.level or 0 ) ) ) and ( u.password or msg_unknown ) or msg_no_allowed,
-                    u.by or msg_unknown,
-                    u.date or msg_unknown,
-                    get_lastlogout( u )
-                ))
+                if u.level >= user_level then
+                    table_insert( ret, utf_format( msg_result_nick, u.nick ) )
+                else
+                    table_insert( ret, utf_format(
+                        msg_result,
+                        u.nick,
+                        u.level or msg_unknown,
+                        ( ( user_level == 100 ) or ( user_level > ( u.level or 0 ) ) ) and ( u.password or msg_unknown ) or msg_no_allowed,
+                        u.by or msg_unknown,
+                        u.date or msg_unknown,
+                        get_lastlogout( u )
+                    ))
+                end
             else
                 max_limit_reached = true
             end

--- a/scripts/cmd_usersearch.lua
+++ b/scripts/cmd_usersearch.lua
@@ -4,6 +4,9 @@
 
         usage: [+!#]usersearch <searchstring>
 
+        v1.2: by HypoManiac
+            - Only shows nick for users with same or higher level.
+            
         v1.1: by blastbeat
             - password only revealed for lower level users  / thx Sopor
 
@@ -49,7 +52,7 @@
 --------------
 
 local scriptname = "cmd_usersearch"
-local scriptversion = "1.1"
+local scriptversion = "1.2"
 
 local cmd = "usersearch"
 

--- a/scripts/lang/cmd_usersearch.lang.de
+++ b/scripts/lang/cmd_usersearch.lang.de
@@ -10,12 +10,13 @@
     ucmd_popup = "Suche nach Nickname",
 
     msg_result = "\n\tNick: %s\n\tLevel: %s\n\tPasswort: %s\n\tRegistriert von: %s\n\tRegistriert am: %s\n\tZuletzt online: %s",
+    msg_result_nick = "\n\tNick: %s",
     msg_no_matches = "Keine Übereinstimmung gefunden",
     msg_no_allowed = "Keine ausreichende Berechtigung",
     msg_unknown = "<UNBEKANNT>",
     msg_denied = "Du bist nicht befugt diesen Befehl zu nutzen.",
     msg_online = "User ist online",
-    
+
     msg_years = " Jahre, ",
     msg_days = " Tage, ",
     msg_hours = " Stunden, ",

--- a/scripts/lang/cmd_usersearch.lang.en
+++ b/scripts/lang/cmd_usersearch.lang.en
@@ -10,12 +10,13 @@
     ucmd_popup = "Search registered nick",
 
     msg_result = "\n\tNick: %s\n\tLevel: %s\n\tPassword: %s\n\tRegged by: %s\n\tRegged since: %s\n\tLast seen: %s",
+    msg_result_nick = "\n\tNick: %s",
     msg_no_matches = "No matches found",
     msg_no_allowed = "Not allowed to view",
     msg_unknown = "<UNKNOWN>",
     msg_denied = "You are not allowed to use this command.",
     msg_online = "user is online",
-    
+
     msg_years = " years, ",
     msg_days = " days, ",
     msg_hours = " hours, ",


### PR DESCRIPTION
!usersearch will only show the nick on people of same or higher level.

A suggested solution for #43 

I opted for creating a new language variable, instead of using substring to cut the existing msg_result.
Thought the code looked cleaner this way.