### PR TITLE
usr_uptime.lua: Wrong Time

### DIFF
--- a/scripts/usr_uptime.lua
+++ b/scripts/usr_uptime.lua
@@ -294,6 +294,7 @@ hub.setlistener( "onTimer", {},
             util_savetable( uptime_tbl, "uptime", uptime_file )
             start = os_time()
         end
+        return nil
     end
 )
 

--- a/scripts/usr_uptime.lua
+++ b/scripts/usr_uptime.lua
@@ -5,7 +5,6 @@
         usage: [+!#]useruptime [CT1 <FIRSTNICK> | CT2 <NICK>]
 
         v0.4
-            - fixed showing uptime of wrong user when selecting user from userlist
             - saves uptime table every 10 minutes
 
         v0.3:


### PR DESCRIPTION
This should fix issue #14.  
  
The hub will save the table every 10 minutes, if no logins/logouts have happened. To avoid excessive disk operations, the login/logout functions resets the timer.