### PR TITLE
Remove python2 dependency from make_keyprint.sh

### DIFF
--- a/examples/certs/make_keyprint.sh
+++ b/examples/certs/make_keyprint.sh
@@ -49,4 +49,12 @@
 #
 # PS: Für alle Windows User unter euch: Installiert euch "cygwin" und kopiert euch die beiden Dateien "make_keyprint.sh" und "servercert.pem" in das "/cygwin" Verzeichnis und startet euer "Cygwin Terminal"
 
-openssl x509 -noout -fingerprint -sha256 < "$1" | cut -d '=' -f 2 | tr -dc "[A-F][0-9]" | python -c "import sys; import base64; keyp=base64.b32encode(base64.b16decode(sys.stdin.readline())); print 'generate keyprint...'; print 'done.'; print 'create file and save keyprint...'; f=file('keyprint.txt', 'w'); f.write(keyp.replace('=', '')); f.close(); print 'done.'; print 'the keyprint.txt was created.'; print 'your SHA256 keyprint hash is:'; print keyp;" | tr -d "="
+KEYPRINT=$(openssl x509 -noout -fingerprint -sha256 < "$1" \
+	| cut -d '=' -f 2 \
+	| tr -d ":" \
+	| xxd -r -ps \
+	| base32 \
+	| tr -d "=")
+
+echo "${KEYPRINT}" | tee keyprint.txt
+echo "Keyprint saved to keyprint.txt"

--- a/examples/certs/make_keyprint.sh
+++ b/examples/certs/make_keyprint.sh
@@ -31,23 +31,23 @@
 # --// german description //--
 #
 # Einen KeyPrint generieren, auf Basis des Luadch Zertifikates (servercert.pem)
-# Durch einen an die Adresse hinzugefügten "KeyPrint" kurz "KP" werden "man in the middle" Attacken vermieden.
-# Der Client prüft mit einer "KeyPrint" versehenen Adresse automatisch das Serverzertifikat und verbindet nur wenn das Zertifikat authentisch ist.
+# Durch einen an die Adresse hinzugefÃ¼gten "KeyPrint" kurz "KP" werden "man in the middle" Attacken vermieden.
+# Der Client prÃ¼ft mit einer "KeyPrint" versehenen Adresse automatisch das Serverzertifikat und verbindet nur wenn das Zertifikat authentisch ist.
 #
 # Beispiel: "adcs://your.host.addy.org:5001/?kp=SHA256/7KGKGB44A5AEPZXTNLVBIAE4HLNVBUO42ONIELL2XYFS4RTPMIYT"
 #
 # Benutzung:
 #
-#   - Die folgenden Pakete müssen installiert sein: "openssl" und "python"
+#   - Die folgenden Pakete mÃ¼ssen installiert sein: "openssl" und "python"
 #   - In folgendes Verzeichnis gehn: "luadch/certs"
 #   - Befehl: chmod 755 make_keyprint.sh
 #   - Befehl: sh make_keyprint.sh servercert.pem
-#   - Öffne: "luadch/cfg/cfg.tbl"
+#   - Ã–ffne: "luadch/cfg/cfg.tbl"
 #   - Einstellung: use_keyprint = true
 #   - Einstellung: keyprint_hash = "<your_kp>"
 #   - Hub neustarten
 #
-# PS: Für alle Windows User unter euch: Installiert euch "cygwin" und kopiert euch die beiden Dateien "make_keyprint.sh" und "servercert.pem" in das "/cygwin" Verzeichnis und startet euer "Cygwin Terminal"
+# PS: FÃ¼r alle Windows User unter euch: Installiert euch "cygwin" und kopiert euch die beiden Dateien "make_keyprint.sh" und "servercert.pem" in das "/cygwin" Verzeichnis und startet euer "Cygwin Terminal"
 
 KEYPRINT=$(openssl x509 -noout -fingerprint -sha256 < "$1" \
 	| cut -d '=' -f 2 \

--- a/examples/certs/make_keyprint.sh
+++ b/examples/certs/make_keyprint.sh
@@ -7,7 +7,7 @@
 #
 #
 # --// english description //--
-# 
+#
 # This bash script generates a keyprint of a particular certificate in Linux, as used in the KEYP extension.
 # The script uses OpenSSL, filters all the verbosity OpenSSL adds and then uses Python to encode it into Base32.
 # The script first calls OpenSSL to get the fingerprint then remove the verbosity and the colons convert with Python and remove any padding.


### PR DESCRIPTION
Replacing the python2 dependency with `xxd` (base16 decode) and `base32` (base32 encode), which come preinstalled on most distributions.

Python 2.x has long reached its EOL and really shouldn't be used anywhere anymore.